### PR TITLE
Dual nic

### DIFF
--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -222,7 +222,7 @@ func (nw *network) deleteEndpoint(nl netlink.NetlinkInterface, plc platform.Exec
 
 	// Remove the endpoint object.
 	delete(nw.Endpoints, endpointID)
-	logger.Info("Deleted endpoint. Num of endpoints", zap.Any("ep", ep), zap.Int("numEndpoints", len(nw.Endpoints)))
+	logger.Info("Deleting endpoint from network", zap.Any("ep", ep), zap.Int("numEndpoints", len(nw.Endpoints)))
 	return nil
 }
 

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -222,7 +222,7 @@ func (nw *network) deleteEndpoint(nl netlink.NetlinkInterface, plc platform.Exec
 
 	// Remove the endpoint object.
 	delete(nw.Endpoints, endpointID)
-	logger.Info("Deleting endpoint from network", zap.Any("ep", ep), zap.Int("numEndpoints", len(nw.Endpoints)))
+	logger.Info("Deleted endpoint. Num of endpoints", zap.Any("ep", ep), zap.Int("numEndpoints", len(nw.Endpoints)))
 	return nil
 }
 

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -543,9 +543,12 @@ func (client *TransparentVlanEndpointClient) ConfigureContainerInterfacesAndRout
 		}
 
 		virtualGwIp, virtualGwIpNet, _ := net.ParseCIDR(virtualGwIPVlanString)
+
+		// IP[14] is the c in a.b.c.d IPv4 format
 		virtualGwIp[14] += byte(len(existingRoutes))
 		virtualGwIpNetString := (&net.IPNet{IP: virtualGwIp, Mask: virtualGwIpNet.Mask}).String()
 
+		// epInfo.IPAddresses always has 1 element on linux ?
 		epAddr := epInfo.IPAddresses[0]
 		routeSubnet := net.IPNet{IP: epAddr.IP.Mask(epAddr.Mask), Mask: epAddr.Mask}
 

--- a/network/transparent_vlan_endpointclient_linux.go
+++ b/network/transparent_vlan_endpointclient_linux.go
@@ -485,13 +485,13 @@ func (client *TransparentVlanEndpointClient) ConfigureContainerInterfacesAndRout
 	return nil
 }
 
-func (client *TransparentVlanEndpointClient) DefaultRouteExists() (bool, error) {
+func (client *TransparentVlanEndpointClient) GetDefaultRoutes() ([]*netlink.Route, error) {
 	_, defaultRoute, _ := net.ParseCIDR(defaultGwCidr)
 	defaultRoutes, err := client.netlink.GetIPRoute(&netlink.Route{Dst: defaultRoute})
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	return len(defaultRoutes) > 0, nil
+	return defaultRoutes, nil
 }
 
 func (client *TransparentVlanEndpointClient) GetExistingVirtualGateways() ([]*netlink.Route, error) {
@@ -530,13 +530,13 @@ func (client *TransparentVlanEndpointClient) ConfigureContainerInterfacesAndRout
 		}
 	}
 
-	defaultRouteExists, err := client.DefaultRouteExists()
+	defaultRoutes, err := client.GetDefaultRoutes()
 	if err != nil {
 		errors.Wrap(err, "failed to get default ip routes in container ns")
 	}
 
 	// DUAL NIC: fix container default route conflict
-	if defaultRouteExists {
+	if len(defaultRoutes) > 0 {
 		existingRoutes, err := client.GetExistingVirtualGateways()
 		if err != nil {
 			return errors.Wrap(err, "failed to get virtual gw ip routes in container ns")


### PR DESCRIPTION
Added dual nic / arbitrary nic support.

The problem was the current code always adds the default route to a fixed IP (169.254.2.1) which means only one nic can be added.

This PoC checks if there is a default route, and if there is, it adds a route for the injected subnet only and it calculates the virtual gateway IP by counting existing routes to the virtual gateway IPs. 